### PR TITLE
run unit tests through workflows

### DIFF
--- a/.github/workflows/networktest1.yml
+++ b/.github/workflows/networktest1.yml
@@ -1,8 +1,7 @@
 name: 'Run Network Test 1'
  
 on:
-  push:
-    branches: [ main ]
+
   workflow_dispatch:
   
 concurrency:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,47 @@
+name: 'Run Unit Tests'
+ 
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+ 
+jobs:
+  run-network-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19.x'
+
+      - name: Run Unit Tests
+        run: |
+          cd crypto
+          go test
+          cd ..
+
+          cd definition
+          go test
+          cd ..
+
+          cd Gen
+          go test
+          cd ..
+          
+          cd gossiper 
+          go test 
+          cd ..
+
+          cd Logger 
+          go test 
+          cd ..
+
+          cd monitor 
+          go test 
+          cd ..
+

--- a/Logger/logger_test.go
+++ b/Logger/logger_test.go
@@ -27,7 +27,10 @@ func TestMerkleTree(t *testing.T) {
 		})
 	}
 	periodNum := 0
-	ctx := InitializeLoggerContext("testFiles/logger_testconfig/1/Logger_public_config.json", "testFiles/logger_testconfig/1/Logger_private_config.json", "testFiles/logger_testconfig/1/Logger_crypto_config.json")
+	ctx := InitializeLoggerContext("../tests/networktests/logger_testconfig/1/Logger_public_config.json",
+		"../tests/networktests/logger_testconfig/1/Logger_private_config.json",
+		"../tests/networktests/logger_testconfig/1/Logger_crypto_config.json",
+	)
 	_, sth, nodes := BuildMerkleTreeFromCerts(certs, *ctx, periodNum)
 	testExistsSubjectKeyId, _ := json.Marshal(2)
 	testCertExists := x509.Certificate{Version: 2, SubjectKeyId: testExistsSubjectKeyId}


### PR DESCRIPTION
Workflow to run unit tests. Also change it so network tests only run on demand, and fixes an issue with logger test using outdated file format. 